### PR TITLE
Add sgkit version attribute to datasets #748

### DIFF
--- a/sgkit/model.py
+++ b/sgkit/model.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Hashable, List, Optional
 import numpy as np
 import xarray as xr
 
+import sgkit as sg
+
 from .typing import ArrayLike
 from .utils import create_dataset
 
@@ -80,7 +82,12 @@ def create_genotype_call_dataset(
         )
     if variant_id is not None:
         data_vars["variant_id"] = ([DIM_VARIANT], variant_id)
-    attrs: Dict[Hashable, Any] = {"contigs": variant_contig_names}
+    attrs: Dict[Hashable, Any] = {
+        "contigs": variant_contig_names,
+        # "source" attribute records which version of sgkit the dataset was created with
+        # following CF Conventions https://cfconventions.org/Data/cf-conventions/cf-conventions-1.9/cf-conventions.html#description-of-file-contents
+        "source": f"sgkit-{sg.__version__}",
+    }
     return create_dataset(data_vars=data_vars, attrs=attrs)
 
 

--- a/sgkit/tests/test_model.py
+++ b/sgkit/tests/test_model.py
@@ -6,6 +6,7 @@ from sgkit import (
     DIM_PLOIDY,
     DIM_SAMPLE,
     DIM_VARIANT,
+    __version__,
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
     display_genotypes,
@@ -41,6 +42,7 @@ def test_create_genotype_call_dataset():
     assert DIM_PLOIDY in ds.dims
     assert DIM_ALLELE in ds.dims
 
+    assert ds.attrs["source"] == f"sgkit-{__version__}"
     assert ds.attrs["contigs"] == variant_contig_names
     assert_array_equal(ds["variant_contig"], variant_contig)
     assert_array_equal(ds["variant_position"], variant_position)


### PR DESCRIPTION
I used the `source` attribute, following [CF conventions](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.9/cf-conventions.html#description-of-file-contents).

For example:

```
<xarray.Dataset>
Dimensions:               (variants: 9, samples: 3, ploidy: 2, alleles: 4)
Dimensions without coordinates: variants, samples, ploidy, alleles
Data variables:
    call_genotype         (variants, samples, ploidy) int8 dask.array<chunksize=(5, 2, 2), meta=np.ndarray>
    call_genotype_mask    (variants, samples, ploidy) bool dask.array<chunksize=(5, 2, 2), meta=np.ndarray>
    call_genotype_phased  (variants, samples) bool dask.array<chunksize=(5, 2), meta=np.ndarray>
    sample_id             (samples) <U7 dask.array<chunksize=(2,), meta=np.ndarray>
    variant_allele        (variants, alleles) object dask.array<chunksize=(5, 4), meta=np.ndarray>
    variant_contig        (variants) int8 dask.array<chunksize=(5,), meta=np.ndarray>
    variant_id            (variants) object dask.array<chunksize=(5,), meta=np.ndarray>
    variant_id_mask       (variants) bool dask.array<chunksize=(5,), meta=np.ndarray>
    variant_position      (variants) int32 dask.array<chunksize=(5,), meta=np.ndarray>
Attributes:
    contigs:               ['19', '20', 'X']
    max_alt_alleles_seen:  3
    source:                sgkit-0.3.1.dev5+g59736c0
```