### PR TITLE
Use custom image for GPU runner on Cirun

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -8,8 +8,10 @@ runners:
     gpu: nvidia-tesla-t4
     # Cheapest VM on GCP, with GPU attachable
     instance_type: n1-standard-1
-    # Ubuntu-20.4, can be seen from "gcloud compute images list"
-    machine_image: ubuntu-minimal-2004-lts
+    # Custom image with NVIDIA drivers installed on Ubuntu-20.4
+    # to reduce provision time
+    # Format => project_name:image_name
+    machine_image: sgkit-dev:cirun-nvidia
     # preemptible instances seems quite less reliable.
     preemptible: false
     # Path of the relevant workflow file


### PR DESCRIPTION
This will make the spinup time faster (about 2x) and makes it more stable.

Most of the time was initially spent in installation of NVIDIA drivers, this makes use of the custom image I created with NVIDIA drivers installed.