### PR TITLE
VCF benchmarks

### DIFF
--- a/sgkit/tests/io/vcf/test_vcf_benchmark.py
+++ b/sgkit/tests/io/vcf/test_vcf_benchmark.py
@@ -4,6 +4,7 @@ import shutil
 import time
 
 from sgkit.io.vcf.vcf_reader import vcf_to_zarr
+from sgkit.io.vcf.vcf_writer import zarr_to_vcf
 from sgkit.tests.io.vcf.utils import path_for_test
 
 
@@ -35,6 +36,37 @@ def test_vcf_read_speed(shared_datadir, tmp_path):
     speed = bytes_read / (1_000_000 * duration)
 
     print(f"bytes read: {bytes_read}")
+    print(f"duration: {duration:.2f} s")
+    print(f"speed: {speed:.1f} MB/s")
+
+
+def test_vcf_write_speed(shared_datadir, tmp_path):
+    path = path_for_test(
+        shared_datadir,
+        "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf.gz",
+    )
+    output_zarr = tmp_path.joinpath("1000G.zarr").as_posix()
+    output_vcf = tmp_path.joinpath("1000G.vcf").as_posix()
+
+    field_defs = {
+        "FORMAT/AD": {"Number": "R"},
+    }
+    vcf_to_zarr(
+        path,
+        output_zarr,
+        fields=["INFO/*", "FORMAT/*"],
+        field_defs=field_defs,
+        chunk_length=1_000,
+    )
+
+    # throw away first run due to numba jit compilation
+    for _ in range(2):
+        duration = time_func(zarr_to_vcf, output_zarr, output_vcf)
+
+    bytes_written = os.path.getsize(output_vcf)
+    speed = bytes_written / (1_000_000 * duration)
+
+    print(f"bytes written: {bytes_written}")
     print(f"duration: {duration:.2f} s")
     print(f"speed: {speed:.1f} MB/s")
 


### PR DESCRIPTION
This is not ready for merging, but shows the current status of VCF read and write speed (#936 and #924).

```
sgkit/tests/io/vcf/test_vcf_benchmark.py::test_vcf_read_speed bytes read: 78683380
duration: 2.69 s
speed: 29.3 MB/s
PASSED
sgkit/tests/io/vcf/test_vcf_benchmark.py::test_vcf_write_speed [W::vcf_parse_format] Extreme FORMAT/AD value encountered and set to missing at 20:10000054
bytes written: 79602637
duration: 99.27 s
speed: 0.8 MB/s
PASSED
```

It should be possible to get both to ~100MB/s.