### PR TITLE
Disable validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,7 +3,9 @@ name: Validation
 on:
   schedule:
     # Run at the end of every day
-    - cron: "0 0 * * *"
+    # Disabled on 2024-09-02 as this has been broken for over a year, and no-one is interested
+    # in fixing it. https://github.com/sgkit-dev/sgkit/issues/1112
+    # - cron: "0 0 * * *"
   # manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
I've seen the notification that his has failed hundreds of times now, and I don't see anyone interested in fixing it. Let's disable it.
