### PR TITLE
Update actions/upload-artifact to v4 in .github/workflows

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -34,12 +34,12 @@ jobs:
       run: |
         cd docs
         make html SPHINXOPTS="-W --keep-going -n"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: gwas_tutorial
         path: /home/runner/work/sgkit/sgkit/docs/_build/html/reports/examples/gwas_tutorial.err.log
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: relatedness_tutorial

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
         python setup.py sdist bdist_wheel
         python -m twine check --strict dist/*
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: dist
 


### PR DESCRIPTION
The docs build has been failing since [upload-artifact v2 has been deprecated](https://github.com/actions/upload-artifact)