### PR TITLE
Simple chunked pedigree kinship

### DIFF
--- a/.github/workflows/build-numpy-2.yml
+++ b/.github/workflows/build-numpy-2.yml
@@ -27,12 +27,6 @@ jobs:
         pip install -U 'numpy<2.1' -U git+https://github.com/sgkit-dev/bio2zarr.git
     # - name: Run pre-commit
     #   uses: pre-commit/action@v2.0.0
-    - name: Test with pytest (numba jit disabled)
-      env:
-        NUMBA_DISABLE_JIT: 1
-      run: |
-        # avoid guvectorized functions #1194
-        pytest -v sgkit/tests/test_pedigree.py
     - name: Test with pytest and coverage
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,6 @@ jobs:
         pip install -r requirements.txt -r requirements-dev.txt
     - name: Run pre-commit
       uses: pre-commit/action@v2.0.0
-    - name: Test with pytest (numba jit disabled)
-      env:
-        NUMBA_DISABLE_JIT: 1
-      run: |
-        # avoid guvectorized functions #1194
-        pytest -v sgkit/tests/test_pedigree.py
     - name: Test with pytest and coverage
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ New Features
 
 - Add 'matching' method to :func:`identity_by_state` function.
   (:user:`timothymillar`, :pr:`1229`, :issue:`1227`)
+- Add 'chunks' option to :func:`pedigree_kinship` function.
+  (:user:`timothymillar`, :pr:`1282`, :issue:`1280`)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/sgkit/stats/pedigree_numba_fns.py
+++ b/sgkit/stats/pedigree_numba_fns.py
@@ -2,7 +2,17 @@
 # in a separate file here, and imported dynamically to avoid
 # initial compilation overhead.
 
-from sgkit.accelerate import numba_guvectorize
+import numpy as np
+from numba import float64
+from numba.experimental import jitclass
+
+from sgkit.accelerate import numba_guvectorize, numba_jit
+from sgkit.stats.pedigree import (
+    _ancestor_depth,
+    _kinship_diploid,
+    _kinship_hamilton_kerr,
+    topological_argsort,
+)
 from sgkit.typing import ArrayLike
 
 
@@ -64,3 +74,109 @@ def contribution_from(
                     p_con = out[p]
                     if p_con >= 0.0:
                         out[j] += p_con * parent_contribution[j, pdx]
+
+
+@numba_jit(nogil=True)
+def _chunk_sub_pedigree(parent, rows, cols):  # pragma: no cover
+    initial = np.zeros(len(parent), np.bool_)
+    initial[rows] = True
+    initial[cols] = True
+    order = topological_argsort(parent)
+    include = _ancestor_depth(initial, parent=parent, order=order) >= 0
+    n_sample, n_parent = parent.shape
+    assert len(include) == n_sample
+    n_new = include.sum()
+    # map old to new indices without reordering the pedigree
+    old_to_new = np.full(n_sample + 1, -1, np.int64)  # always map -1 to -1
+    new_to_old = np.full(n_new, -1, np.int64)
+    new = 0
+    for old in range(n_sample):
+        if include[old]:
+            old_to_new[old] = new
+            new_to_old[new] = old
+            new += 1
+    assert new == n_new
+    # build new parent matrix
+    sub_ped = np.full((n_new, n_parent), -1, np.int64)
+    for old in range(n_sample):
+        if include[old]:
+            new = old_to_new[old]
+            for j in range(n_parent):
+                p_old = parent[old, j]
+                if include[p_old]:
+                    p_new = old_to_new[p_old]
+                    sub_ped[new, j] = p_new
+    return sub_ped, old_to_new[rows], old_to_new[cols], new_to_old
+
+
+_triangular_matrix_spec = [
+    ("values", float64[:]),
+]
+
+
+@numba_jit(nogil=True)
+def _triangular_matrix_idx(i, j):  # pragma: no cover
+    if i > j:
+        return j + (i * (i + 1) // 2)
+    else:
+        return i + (j * (j + 1) // 2)
+
+
+@jitclass(_triangular_matrix_spec)
+class _triangular_matrix(object):  # pragma: no cover
+    def __init__(self, n):
+        self.values = np.zeros(n + ((n**2 - n) // 2), dtype=np.float64)
+
+    def __getitem__(self, index):
+        i, j = index
+        return self.values[_triangular_matrix_idx(i, j)]
+
+    def __setitem__(self, index, value):
+        i, j = index
+        self.values[_triangular_matrix_idx(i, j)] = value
+
+
+@numba_guvectorize(  # type: ignore
+    [
+        "void(int64[:,:], int64[:], int64[:], boolean[:], float64[:,:])",
+    ],
+    "(n,p),(r),(c),()->(r,c)",
+)
+def kinship_diploid_chunk(
+    parent, rows, cols, allow_half_founders, out
+):  # pragma: no cover
+    parent, rows, cols, _ = _chunk_sub_pedigree(parent, rows, cols)
+    triangle = _triangular_matrix(len(parent))
+    _kinship_diploid(parent, triangle, allow_half_founders[0])
+    for i in range(len(rows)):
+        x = rows[i]
+        for j in range(len(cols)):
+            y = cols[j]
+            out[i, j] = triangle[x, y]
+
+
+@numba_guvectorize(  # type: ignore
+    [
+        "void(int64[:,:], uint64[:,:], float64[:,:], int64[:], int64[:], boolean[:], float64[:,:])",
+    ],
+    "(n,p),(n,p),(n,p),(r),(c),()->(r,c)",
+)
+def kinship_Hamilton_Kerr_chunk(
+    parent, tau, lambda_, rows, cols, allow_half_founders, out
+):  # pragma: no cover
+    parent, rows, cols, kept = _chunk_sub_pedigree(parent, rows, cols)
+    tau = tau[kept]
+    lambda_ = lambda_[kept]
+    triangle = _triangular_matrix(len(parent))
+    _kinship_hamilton_kerr(
+        parent=parent,
+        tau=tau,
+        lambda_=lambda_,
+        out=triangle,
+        allow_half_founders=allow_half_founders[0],
+    )
+    for i in range(len(rows)):
+        x = rows[i]
+        for j in range(len(cols)):
+            y = cols[j]
+            out[i, j] = triangle[x, y]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Fixes #1280
- [x] Fixes #1213
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`


I've tested this with a real pedigree of ~55,000 individuals on a 4-core laptop in WSL2. I can calculate the pedigree matrix using chunks of 5000 samples and save the chunked matrix to a Zarr store in a total of < 25s using ~2.5GB of RAM. The full matrix would be ~22.5GB which exceeds the memory of this machine.

I've used the `@jitclass` experimental feature from Numba for a simple triangular matrix class. Using a triangular matrix halves the RAM needed for the intermediate matrices. It's not strictly necessary to use `@jitclass` for this but it allows for greater code reuse via custom `__setitem__`/`__getitem__`. If this is an issue it could be reworked to avoid `@jitclass`.

I've also removed the test runs with `NUMBA_DISABLE_JIT: 1` because this introduces a dependency on `@guvectorize` and `@jitclass` in `pedigree.py`.