### PR TITLE
Remove NumPy<2 pin

### DIFF
--- a/.github/workflows/build-numpy-1.yml
+++ b/.github/workflows/build-numpy-1.yml
@@ -1,4 +1,4 @@
-name: Build NumPy 2
+name: Build NumPy 1
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -22,9 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-numpy2.txt -r requirements-numpy2-dev.txt
-        # update bio2zarr for NumPy 2, see https://github.com/sgkit-dev/bio2zarr/issues/256
-        pip install -U 'numpy<2.1' -U git+https://github.com/sgkit-dev/bio2zarr.git
+        pip install -r requirements-numpy1.txt -r requirements-numpy1-dev.txt
     # - name: Run pre-commit
     #   uses: pre-commit/action@v2.0.0
     - name: Test with pytest and coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +28,7 @@ jobs:
         sudo apt install graphviz  # Needed for documentation
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
+        pip install -U dask distributed  # need latest versions to successully build docs
     - name: Run pre-commit
       uses: pre-commit/action@v2.0.0
     - name: Check for Sphinx doc warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,14 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         sudo apt update -y
         sudo apt install graphviz  # Needed for documentation
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
+        pip install -U dask distributed  # need latest versions to successully build docs
     - name: Build Sphinx documentation
       run: |
         cd docs

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,8 +29,11 @@ Breaking changes
 .. Deprecations
 .. ~~~~~~~~~~~~
 
-.. Improvements
-.. ~~~~~~~~~~~~
+Improvements
+~~~~~~~~~~~~
+
+- Add support for NumPy 2.
+  (:user:`tomwhite`, :pr:`1297`)
 
 .. Bug fixes
 .. ~~~~~~~~~

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ scikit-learn
 partd
 bed-reader
 rechunker
-cbgen < 1.0.5
+cbgen > 1.0.5
 bio2zarr @ git+https://github.com/sgkit-dev/bio2zarr.git; platform_system != "Windows"
 yarl
 matplotlib

--- a/requirements-numpy1-dev.txt
+++ b/requirements-numpy1-dev.txt
@@ -12,7 +12,8 @@ scikit-learn
 partd
 bed-reader
 rechunker
-cbgen > 1.0.5
+cbgen < 1.0.5
+bio2zarr @ git+https://github.com/sgkit-dev/bio2zarr.git; platform_system != "Windows"
 yarl
 matplotlib
 asv

--- a/requirements-numpy1.txt
+++ b/requirements-numpy1.txt
@@ -1,4 +1,4 @@
-numpy < 2.1
+numpy < 2
 xarray < 2025.03.1
 dask[array,dataframe] >= 2023.01.0, <= 2024.8.0
 distributed >= 2023.01.0, <= 2024.8.0

--- a/requirements-numpy2.txt
+++ b/requirements-numpy2.txt
@@ -1,5 +1,5 @@
 numpy < 2.1
-xarray
+xarray < 2025.03.1
 dask[array,dataframe] >= 2023.01.0, <= 2024.8.0
 distributed >= 2023.01.0, <= 2024.8.0
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy < 2
+numpy < 2.2
 xarray < 2025.03.1
 dask[array,dataframe] >= 2023.01.0, <= 2024.8.0
 distributed >= 2023.01.0, <= 2024.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy < 2
-xarray
+xarray < 2025.03.1
 dask[array,dataframe] >= 2023.01.0, <= 2024.8.0
 distributed >= 2023.01.0, <= 2024.8.0
 scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.10
 install_requires =
-    numpy < 2
+    numpy < 2.2
     xarray < 2025.03.1
     dask[array,dataframe] >= 2022.01.0, <= 2024.8.0
     distributed >= 2022.01.0, <= 2024.8.0
@@ -60,7 +60,7 @@ plink =
     bed-reader
 bgen =
     rechunker
-    cbgen < 1.0.5
+    cbgen > 1.0.5
 
 [coverage:report]
 fail_under = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 python_requires = >=3.10
 install_requires =
     numpy < 2
-    xarray
+    xarray < 2025.03.1
     dask[array,dataframe] >= 2022.01.0, <= 2024.8.0
     distributed >= 2022.01.0, <= 2024.8.0
     scipy

--- a/sgkit/stats/pca.py
+++ b/sgkit/stats/pca.py
@@ -325,7 +325,7 @@ def count_call_alternate_alleles(ds: Dataset, merge: bool = True) -> Dataset:
     # TODO: Add to public API (https://github.com/sgkit-dev/sgkit/issues/282)
     AC = count_call_alleles(ds)["call_allele_count"]
     AC = AC[..., 1:].sum(dim="alleles").astype("int16")
-    AC = AC.where(~ds.call_genotype_mask.any(dim="ploidy"), AC.dtype.type(-1))
+    AC = AC.where(~ds.call_genotype_mask.any(dim="ploidy"), -1)
     new_ds = Dataset({"call_alternate_allele_count": AC})
     return conditional_merge_datasets(ds, new_ds, merge)
 


### PR DESCRIPTION
This comes from a request that @benjeffery made in the meeting yesterday. NumPy 2 has been out for a while now, and has proved stable (in other projects), so it makes sense to remove the pin - and make NumPy 2 the default. I've kept tests for NumPy 1.

- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
