### PR TITLE
doc: add copybutton to code snippets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
+    "sphinx_copybutton",
     "scanpydoc",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,6 +2,7 @@ myst_nb
 pydata-sphinx-theme
 sphinx==6.2.1
 sphinx_autodoc_typehints>=1.14.0
+sphinx-copybutton
 scanpydoc
 ipython
 matplotlib


### PR DESCRIPTION
Add https://sphinx-copybutton.readthedocs.io/en/latest/ to the doc build. This adds a handy button on code snippets that enables copying the entire block

