### PR TITLE
build: adjust github action for pyproject.toml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,8 @@
 name: Wheels
 
 on:
+  # temporarily add PR for this PR to test
+  pull_request:
   push:
     branches:
       - main
@@ -28,10 +30,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools twine wheel
+        pip install setuptools twine wheel build
     - name: Build a source distribution and a wheel
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
         python -m twine check --strict dist/*
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Should fix. I also added a line to run the action on PRs so it can be tested here. Can remove before merging..

- [x] Fixes #1302
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
- [ ] New functions are listed in `api.rst`
