### PR TITLE
Deprecate `rechunk_bgen` that uses rechunker 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,10 @@ Deprecations
 - Functions for reading and writing plink are deprecated, please use the `bio2zarr <https://github.com/sgkit-dev/bio2zarr>`_
   and `vcztools <https://github.com/sgkit-dev/vcztools>`_ packages.
   (:user:`tomwhite`, :pr:`1324`, :issue:`1318`)
+- Using rechunker for rechunking in sgkit is deprecated, please use the the
+  `Xarray chunk <https://docs.xarray.dev/en/stable/generated/xarray.Dataset.chunk.html#xarray.Dataset.chunk>`_
+  function directly.
+  (:user:`tomwhite`, :pr:`1325`)
 
 .. Improvements
 .. ~~~~~~~~~~~~

--- a/sgkit/io/bgen/bgen_reader.py
+++ b/sgkit/io/bgen/bgen_reader.py
@@ -2,6 +2,7 @@
 import logging
 import tempfile
 import time
+import warnings
 from pathlib import Path
 from typing import (
     Any,
@@ -446,6 +447,11 @@ def rechunk_bgen(
     will run inline so calls to it may be slow. The resulting Dataset is
     generated based on the final, serialized Zarr data.
 
+    .. deprecated:: 0.11.0
+       Using rechunker for rechunking in sgkit is deprecated, please use the the
+       `Xarray chunk <https://docs.xarray.dev/en/stable/generated/xarray.Dataset.chunk.html#xarray.Dataset.chunk>`_
+       function directly.
+
     Parameters
     ----------
     ds
@@ -486,6 +492,12 @@ def rechunk_bgen(
     Dataset
         The rechunked dataset.
     """
+    warnings.warn(
+        "Using rechunker for rechunking in sgkit is deprecated, please use the the Xarray 'chunk' function directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if isinstance(output, Path):
         output = str(output)
 


### PR DESCRIPTION
This will allow us to remove the rechunker dependency later on.

Rechunker may be deprecated at some point, see https://github.com/pangeo-data/rechunker/issues/160. Also, we have had build issues due to Xarray and Rechunker version incompatibilities, so it would be good to remove another dependency.

- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

