### PR TITLE
Update diversity definition

### DIFF
--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -29,7 +29,7 @@ def diversity(
     cohort_allele_count: Hashable = variables.cohort_allele_count,
     merge: bool = True,
 ) -> Dataset:
-    """Compute diversity from cohort allele counts.
+    """Compute diversity as the average number of differences between a pair of sequences from cohort allele counts.
 
     By default, values of this statistic are calculated per variant.
     To compute values in windows, call :func:`window_by_position` or :func:`window_by_variant` before calling


### PR DESCRIPTION
Just updating the documentation of the `diversity()` function in `popgen.py` to clarify that diversity is the mean number of differences between a pair of sequences, as opposed to other diversity estimators.

- [ ] Fixes #[1327](https://github.com/sgkit-dev/sgkit/issues/1327)
