### PR TITLE
Implement Garud's G selection statistics for unphased data

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -81,6 +81,7 @@ Population genetic statistics
    divergence
    diversity
    Fst
+   Garud_G
    Garud_H
    individual_heterozygosity
    observed_heterozygosity
@@ -214,6 +215,10 @@ By convention, variable names are singular in sgkit. For example, ``genotype_cou
     variables.stat_divergence_spec
     variables.stat_diversity_spec
     variables.stat_Fst_spec
+    variables.stat_Garud_g1_spec
+    variables.stat_Garud_g12_spec
+    variables.stat_Garud_g123_spec
+    variables.stat_Garud_g2_g1_spec
     variables.stat_Garud_h1_spec
     variables.stat_Garud_h12_spec
     variables.stat_Garud_h123_spec

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -48,6 +48,7 @@ from .stats.pedigree import (
 )
 from .stats.popgen import (
     Fst,
+    Garud_G,
     Garud_H,
     Tajimas_D,
     divergence,
@@ -119,6 +120,7 @@ __all__ = [
     "diversity",
     "divergence",
     "Fst",
+    "Garud_G",
     "Garud_H",
     "Tajimas_D",
     "pbs",

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -604,32 +604,39 @@ def pbs(
     return conditional_merge_datasets(ds, new_ds, merge)
 
 
-N_GARUD_H_STATS = 4  # H1, H12, H123, H2/H1
+N_GARUD_STATS = 4  # H1, H12, H123, H2/H1 or G1, G12, G123, G2/G1
 
 
-def _Garud_h(haplotypes: np.ndarray) -> np.ndarray:
-    # find haplotype counts (sorted in descending order)
-    counts = sorted(collections.Counter(haplotypes.tolist()).values(), reverse=True)
+def _Garud_stat(hashed_genotypes: np.ndarray) -> np.ndarray:
+    """Compute the Garud H or G statistics (H1, H12, H123, H2/H1 or G1, G12, G123, G2/G1).
+
+    This helper is used by both :func:`Garud_H` and :func:`Garud_G` after
+    genotypes are encoded into hashable units:
+    - haplotypes for ``Garud_H``
+    - diplotypes (MLGs) for ``Garud_G``
+    """
+    # find encoded genotype counts (sorted in descending order)
+    counts = sorted(collections.Counter(hashed_genotypes.tolist()).values(), reverse=True)
     counts = np.array(counts)  # type: ignore
 
-    # find haplotype frequencies
-    n = haplotypes.shape[0]
-    f = counts / n  # type: ignore[operator]
+    # find encoded genotype frequencies
+    n = hashed_genotypes.shape[0]
+    p = counts / n  # type: ignore[operator]
 
-    # compute H1
-    h1 = np.sum(f**2)
+    # compute H1 or G1
+    x1 = np.sum(p**2)
 
-    # compute H12
-    h12 = np.sum(f[:2]) ** 2 + np.sum(f[2:] ** 2)  # type: ignore[index]
+    # compute H12 or G12
+    x12 = np.sum(p[:2]) ** 2 + np.sum(p[2:] ** 2)  # type: ignore[index]
 
-    # compute H123
-    h123 = np.sum(f[:3]) ** 2 + np.sum(f[3:] ** 2)  # type: ignore[index]
+    # compute H123 or G123
+    x123 = np.sum(p[:3]) ** 2 + np.sum(p[3:] ** 2)  # type: ignore[index]
 
-    # compute H2/H1
-    h2 = h1 - f[0] ** 2  # type: ignore[index]
-    h2_h1 = h2 / h1
+    # compute H2/H1 or G2/G1
+    x2 = x1 - p[0] ** 2  # type: ignore[index]
+    x2_x1 = x2 / x1
 
-    return np.array([h1, h12, h123, h2_h1])
+    return np.array([x1, x12, x123, x2_x1])
 
 
 def _Garud_h_cohorts(
@@ -639,9 +646,9 @@ def _Garud_h_cohorts(
     from .popgen_numba_fns import hash_array
 
     haplotypes = hash_array(gt.transpose()).transpose().flatten()
-    arr = np.full((n_cohorts, N_GARUD_H_STATS), np.nan)
+    arr = np.full((n_cohorts, N_GARUD_STATS), np.nan)
     for c in np.nditer(ct):
-        arr[c, :] = _Garud_h(haplotypes[sample_cohort == c])
+        arr[c, :] = _Garud_stat(haplotypes[sample_cohort == c])
     return arr
 
 
@@ -762,10 +769,10 @@ def Garud_H(
         ds.window_stop.values,
         dtype=np.float64,
         # first chunks dimension is windows, computed in window_statistic
-        chunks=(-1, n_cohorts, N_GARUD_H_STATS),
+        chunks=(-1, n_cohorts, N_GARUD_STATS),
     )
     n_windows = ds.window_start.shape[0]
-    assert_array_shape(gh, n_windows, n_cohorts, N_GARUD_H_STATS)
+    assert_array_shape(gh, n_windows, n_cohorts, N_GARUD_STATS)
     new_ds = create_dataset(
         {
             variables.stat_Garud_h1: (
@@ -783,6 +790,133 @@ def Garud_H(
             variables.stat_Garud_h2_h1: (
                 ("windows", "cohorts"),
                 gh[:, :, 3],
+            ),
+        }
+    )
+
+    return conditional_merge_datasets(ds, new_ds, merge)
+
+def _Garud_g_cohorts(
+    gt: np.ndarray, sample_cohort: np.ndarray, n_cohorts: int, ct: np.ndarray
+) -> np.ndarray:
+    # transpose to hash columns (unphased diplotypes)
+    from .popgen_numba_fns import hash_array
+
+    gt = np.sort(gt, axis=2)
+    diplotypes = hash_array(gt.transpose(1, 2, 0).reshape(gt.shape[1], -1))
+    arr = np.full((n_cohorts, N_GARUD_STATS), np.nan)
+    for c in np.nditer(ct):
+        arr[c, :] = _Garud_stat(diplotypes[sample_cohort == c])
+    return arr
+
+
+def Garud_G(
+    ds: Dataset,
+    *,
+    call_genotype: Hashable = variables.call_genotype,
+    sample_cohort: Hashable = variables.sample_cohort,
+    cohorts: Optional[Sequence[Union[int, str]]] = None,
+    merge: bool = True,
+) -> Dataset:
+    """Compute the G1, G12, G123 and G2/G1 statistics for detecting signatures
+    of soft sweeps in diploid genotypes, as defined in Harris et al. (2018).
+
+    This method requires a windowed dataset.
+    To window a dataset, call :func:`window_by_position` or :func:`window_by_variant` before calling
+    this function.
+
+    Parameters
+    ----------
+    ds
+        Genotype call dataset.
+    call_genotype
+        Input variable name holding call_genotype as defined by
+        :data:`sgkit.variables.call_genotype_spec`.
+        Must be present in ``ds``.
+    sample_cohort
+        Input variable name holding sample_cohort as defined by
+        :data:`sgkit.variables.sample_cohort_spec`.
+    cohorts
+        The cohorts to compute statistics for, specified as a sequence of
+        cohort indexes or IDs. None (the default) means compute statistics
+        for all cohorts.
+    merge
+        If True (the default), merge the input dataset and the computed
+        output variables into a single dataset, otherwise return only
+        the computed output variables.
+        See :ref:`dataset_merge` for more details.
+
+    Returns
+    -------
+    A dataset containing the following variables:
+
+    - `stat_Garud_g1` (windows, cohorts): Garud G1 statistic.
+        Defined by :data:`sgkit.variables.stat_Garud_g1_spec`.
+
+    - `stat_Garud_g12` (windows, cohorts): Garud G12 statistic.
+        Defined by :data:`sgkit.variables.stat_Garud_g12_spec`.
+
+    - `stat_Garud_g123` (windows, cohorts): Garud G123 statistic.
+        Defined by :data:`sgkit.variables.stat_Garud_g123_spec`.
+
+    - `stat_Garud_g2_g1` (windows, cohorts): Garud G2/G1 statistic.
+        Defined by :data:`sgkit.variables.stat_Garud_g2_g1_spec`.
+
+    Raises
+    ------
+    NotImplementedError
+        If the dataset is not diploid.
+    ValueError
+        If the dataset is not windowed.
+
+    Warnings
+    --------
+    This function is currently only implemented for diploid datasets.
+    """
+
+    if ds.sizes["ploidy"] != 2:
+        raise NotImplementedError("Garud G only implemented for diploid genotypes")
+
+    if not has_windows(ds):
+        raise ValueError("Dataset must be windowed for Garud_G")
+
+    variables.validate(ds, {call_genotype: variables.call_genotype_spec})
+
+    gt = da.asarray(ds[call_genotype])
+
+    sc = ds[sample_cohort].values
+    n_cohorts = sc.max() + 1  # 0-based indexing
+    cohorts = cohorts or range(n_cohorts)
+    ct = _cohorts_to_array(cohorts, ds.indexes.get("cohorts", None))
+
+    gg = window_statistic(
+        gt,
+        lambda gt: _Garud_g_cohorts(gt, sc, n_cohorts, ct),
+        ds.window_start.values,
+        ds.window_stop.values,
+        dtype=np.float64,
+        # first chunks dimension is windows, computed in window_statistic
+        chunks=(-1, n_cohorts, N_GARUD_STATS),
+    )
+    n_windows = ds.window_start.shape[0]
+    assert_array_shape(gg, n_windows, n_cohorts, N_GARUD_STATS)
+    new_ds = create_dataset(
+        {
+            variables.stat_Garud_g1: (
+                ("windows", "cohorts"),
+                gg[:, :, 0],
+            ),
+            variables.stat_Garud_g12: (
+                ("windows", "cohorts"),
+                gg[:, :, 1],
+            ),
+            variables.stat_Garud_g123: (
+                ("windows", "cohorts"),
+                gg[:, :, 2],
+            ),
+            variables.stat_Garud_g2_g1: (
+                ("windows", "cohorts"),
+                gg[:, :, 3],
             ),
         }
     )

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -13,6 +13,7 @@ from hypothesis import strategies as st
 
 from sgkit import (
     Fst,
+    Garud_G,
     Garud_H,
     Tajimas_D,
     count_cohort_alleles,
@@ -530,6 +531,103 @@ def test_Garud_h__raise_on_no_windows():
 
     with pytest.raises(ValueError, match="Dataset must be windowed for Garud_H"):
         Garud_H(ds)
+
+
+@pytest.mark.parametrize(
+    "n_variants, n_samples, n_contigs, n_cohorts, cohorts, cohort_indexes",
+    [
+        (9, 5, 1, 1, None, None),
+        (9, 5, 1, 2, None, None),
+        (9, 5, 1, 2, [1], [1]),
+        (9, 5, 1, 2, ["co_1"], [1]),
+    ],
+)
+@pytest.mark.parametrize("chunks", [(-1, -1), (5, -1)])
+def test_Garud_g(
+    n_variants, n_samples, n_contigs, n_cohorts, cohorts, cohort_indexes, chunks
+):
+    ds = simulate_genotype_call_dataset(
+        n_variant=n_variants, n_sample=n_samples, n_contig=n_contigs, seed=1
+    )
+    ds = ds.chunk(dict(zip(["variants", "samples"], chunks)))
+    subsets = np.array_split(ds.samples.values, n_cohorts)
+    sample_cohorts = np.concatenate(
+        [np.full_like(subset, i) for i, subset in enumerate(subsets)]
+    )
+    ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
+    cohort_names = [f"co_{i}" for i in range(n_cohorts)]
+    coords = {k: cohort_names for k in ["cohorts"]}
+    ds = ds.assign_coords(coords)
+    ds = window_by_variant(ds, size=3)
+
+    gg = Garud_G(ds, cohorts=cohorts)
+    g1 = gg.stat_Garud_g1.values
+    g12 = gg.stat_Garud_g12.values
+    g123 = gg.stat_Garud_g123.values
+    g2_g1 = gg.stat_Garud_g2_g1.values
+
+    for c in range(n_cohorts):
+        if cohort_indexes is not None and c not in cohort_indexes:
+            # cohorts that were not computed should be nan
+            np.testing.assert_array_equal(g1[:, c], np.full_like(g1[:, c], np.nan))
+            np.testing.assert_array_equal(g12[:, c], np.full_like(g12[:, c], np.nan))
+            np.testing.assert_array_equal(g123[:, c], np.full_like(g123[:, c], np.nan))
+            np.testing.assert_array_equal(
+                g2_g1[:, c], np.full_like(g2_g1[:, c], np.nan)
+            )
+        else:
+            # External validation reference for this deterministic case:
+            # simulated by:
+            #   ds = simulate_genotype_call_dataset(
+            #       n_variant=9, n_sample=5, n_contig=1, seed=1
+            #   )
+            # then converted into SelectionHapStats MLG input using a fixed
+            # diploid-unphased encoding per genotype, as documented in
+            # SelectionHapStats (unphased format):
+            #   homozygous -> allele nucleotide, heterozygous -> '.'
+            # and run with:
+            #   python /tmp/H12_H2H1_py3.py /tmp/sgkit_garud_g_ref_input.csv 5 \
+            #       -w 3 -j 3 -d 0 -o /tmp/sgkit_garud_g_ref_output.tsv
+            # where /tmp/H12_H2H1_py3.py is a Python 3 compatibility copy of
+            # github.com/ngarud/SelectionHapStats/scripts/H12_H2H1.py with:
+            #   - `.iterkeys()` -> `.keys()`
+            #   - `window = int(windowTot)/2` -> `window = int(windowTot)//2`
+            #   - Python 2 print statements converted to Python 3 print calls
+            #
+            # SelectionHapStats output (first two windows; this script does not
+            # emit the final partial/edge window):
+            #   H1=0.20000000000000004, H12=0.28, H2/H1=0.8, H123=0.44000000000000006
+            #   H1=0.20000000000000004, H12=0.28, H2/H1=0.8, H123=0.44000000000000006
+            if (
+                n_variants == 9
+                and n_samples == 5
+                and n_contigs == 1
+                and n_cohorts == 1
+                and cohorts is None
+            ):
+                np.testing.assert_allclose(
+                    g1[:2, c], np.array([0.20000000000000004, 0.20000000000000004])
+                )
+                np.testing.assert_allclose(g12[:2, c], np.array([0.28, 0.28]))
+                np.testing.assert_allclose(
+                    g123[:2, c], np.array([0.44000000000000006, 0.44000000000000006])
+                )
+                np.testing.assert_allclose(g2_g1[:2, c], np.array([0.8, 0.8]))
+
+
+def test_Garud_g__raise_on_non_diploid():
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, n_ploidy=3)
+    with pytest.raises(
+        NotImplementedError, match="Garud G only implemented for diploid genotypes"
+    ):
+        Garud_G(ds)
+
+
+def test_Garud_g__raise_on_no_windows():
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10)
+    with pytest.raises(ValueError, match="Dataset must be windowed for Garud_G"):
+        Garud_G(ds)
+
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -586,9 +586,9 @@ def test_Garud_g(
             # SelectionHapStats (unphased format):
             #   homozygous -> allele nucleotide, heterozygous -> '.'
             # and run with:
-            #   python /tmp/H12_H2H1_py3.py /tmp/sgkit_garud_g_ref_input.csv 5 \
-            #       -w 3 -j 3 -d 0 -o /tmp/sgkit_garud_g_ref_output.tsv
-            # where /tmp/H12_H2H1_py3.py is a Python 3 compatibility copy of
+            #   python H12_H2H1_py3.py sgkit_garud_g_ref_input.csv 5 \
+            #       -w 3 -j 3 -d 0 -o sgkit_garud_g_ref_output.tsv
+            # where H12_H2H1_py3.py is a Python 3 compatibility copy of
             # github.com/ngarud/SelectionHapStats/scripts/H12_H2H1.py with:
             #   - `.iterkeys()` -> `.keys()`
             #   - `window = int(windowTot)/2` -> `window = int(windowTot)//2`
@@ -627,7 +627,6 @@ def test_Garud_g__raise_on_no_windows():
     ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10)
     with pytest.raises(ValueError, match="Dataset must be windowed for Garud_G"):
         Garud_G(ds)
-
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -826,6 +826,42 @@ stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
     )
 )
 
+stat_Garud_g1, stat_Garud_g1_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_Garud_g1",
+        dims=("windows", "cohorts"),
+        kind="f",
+        __doc__="""Garud G1 statistic for cohorts.""",
+    )
+)
+
+stat_Garud_g12, stat_Garud_g12_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_Garud_g12",
+        dims=("windows", "cohorts"),
+        kind="f",
+        __doc__="""Garud G12 statistic for cohorts.""",
+    )
+)
+
+stat_Garud_g123, stat_Garud_g123_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_Garud_g123",
+        dims=("windows", "cohorts"),
+        kind="f",
+        __doc__="""Garud G123 statistic for cohorts.""",
+    )
+)
+
+stat_Garud_g2_g1, stat_Garud_g2_g1_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_Garud_g2_g1",
+        dims=("windows", "cohorts"),
+        kind="f",
+        __doc__="""Garud G2/G1 statistic for cohorts.""",
+    )
+)
+
 stat_genomic_kinship, stat_genomic_kinship_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_genomic_kinship",


### PR DESCRIPTION
After @benjeffery's awesome talk at EIT the other day, I was reminded of a feature I never finished adding to sgkit from over 3 years ago (#980)! not sure how much work is being done on sgkit right now but thought it would be fun to finish it. 

In this PR I add the Garud's G statistics GWSS, that are analogous to the Garud's H statistics but for unphased data. In our experience from mosquito genomics, they tend to work very well. G123 is directly analogous to H12, so most of the code is identical to that implementation (please see the issue #980 for more detail). 

In the PR i've renamed the _Garud_h() function to _Garud_stat(), as it is applicable to both haplotypes (Garuds H stats) and diplotypes/MLGs (Garuds G stats), and I didn't want to duplicate the code with two separate functions. I have used Nandita Garuds original implementation (SelectionHapStats) to generate expected values for tests from the sgkit simulated dataset. 