### PR TITLE
Install Windows CI dependencies with pip instead of conda, test 3.12 too

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,24 +17,16 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Miniconda with Python version ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v7
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
       with:
-        auto-update-conda: true
-        channels: conda-forge,numba
-        miniconda-version: "latest"
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      # activate conda
-      shell: bash -l {0}
-      # conda can't install all dev tools, so we need to split it between conda and pip
       run: |
-        conda install msprime
+        python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
     - name: Test with pytest
-      # activate conda
-      shell: bash -l {0}
       # To avoid: 'UserWarning: KMeans is known to have a memory leak on Windows with MKL, when there are less chunks than available threads. You can avoid it by setting the environment variable OMP_NUM_THREADS=1'
       env:
         OMP_NUM_THREADS: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
The Windows workflow started failing in `test_genee` with warnings treated as errors:

```
RuntimeWarning:
Found Intel OpenMP ('libiomp') and LLVM OpenMP ('libomp') loaded at
the same time. Both libraries are known to be incompatible ...
```

`conda install msprime` on conda-forge now resolves to MKL (`libiomp`) plus `llvm-openmp` (`libomp`), while the pip-installed scientific stack brings its own OpenMP, so threadpoolctl sees both runtimes. I confirmed the failure is independent of the `setup-miniconda` version by running the same job with v2 and v4.

conda was only used on Windows because msprime had no Windows wheels at the time. It now publishes them for Python 3.11 through 3.14, so this switches the job to `setup-python` + pip like the other workflows and drops the miniconda step entirely.

Second commit adds Python 3.12 to the matrix so Windows covers the same versions as the Build workflow.

Verified green on my fork 
- (3.11): https://github.com/Billyzhang1229/sgkit/actions/runs/33775450800/job/100715880709
- (3.12):https://github.com/Billyzhang1229/sgkit/actions/runs/33775450800/job/100715880446