### PR TITLE
Fix Cubed workflow: Python 3.12 and dict chunks

### DIFF
--- a/.github/workflows/cubed.yml
+++ b/.github/workflows/cubed.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/sgkit/stats/pca.py
+++ b/sgkit/stats/pca.py
@@ -51,7 +51,7 @@ def pca_est(
         raise ValueError(
             "PCA can only be performed on arrays chunked in 2 dimensions if algorithm='randomized'. "
             "Consider using this algorithm instead or rechunking the alternate allele counts array "
-            "(e.g. ds.call_alternate_allele_count.chunk((None, -1)))."
+            "(e.g. ds.call_alternate_allele_count.chunk({'samples': -1}))."
         )
 
     return Pipeline(

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -308,8 +308,8 @@ def test_count_cohort_alleles__multi_variant_multi_sample():
 @pytest.mark.parametrize(
     "chunks",
     [
-        (5, -1, -1),
-        (5, 5, -1),
+        {"variants": 5, "samples": -1, "ploidy": -1},
+        {"variants": 5, "samples": 5, "ploidy": -1},
     ],
 )
 def test_count_cohort_alleles__chunked(chunks):
@@ -401,11 +401,11 @@ def test_count_variant_genotypes__biallelic(
     expect = count_biallelic_genotypes(calls, ploidy)
     if chunked:
         # chunk each dim
-        chunks = (
-            (n_variant // 2, n_variant - n_variant // 2),
-            (n_sample // 2, n_sample - n_sample // 2),
-            (ploidy // 2, ploidy - ploidy // 2),
-        )
+        chunks = {
+            "variants": (n_variant // 2, n_variant - n_variant // 2),
+            "samples": (n_sample // 2, n_sample - n_sample // 2),
+            "ploidy": (ploidy // 2, ploidy - ploidy // 2),
+        }
         ds["call_genotype"] = ds["call_genotype"].chunk(chunks)
     actual = count_variant_genotypes(ds)["variant_genotype_count"].data
     np.testing.assert_array_equal(expect, actual)
@@ -571,8 +571,8 @@ def test_count_variant_genotypes__raise_on_mixed_ploidy():
 @pytest.mark.parametrize(
     "chunks",
     [
-        ((4,), (2,), (2,)),
-        ((2, 2), (1, 1), (1, 1)),
+        {"variants": (4,), "cohorts": (2,), "alleles": (2,)},
+        {"variants": (2, 2), "cohorts": (1, 1), "alleles": (1, 1)},
     ],
 )
 def test_cohort_allele_frequencies__diploid(chunks):
@@ -605,8 +605,8 @@ def test_cohort_allele_frequencies__diploid(chunks):
 @pytest.mark.parametrize(
     "chunks",
     [
-        ((4,), (2,), (3,)),
-        ((2, 2), (1, 1), (2, 1)),
+        {"variants": (4,), "cohorts": (2,), "alleles": (3,)},
+        {"variants": (2, 2), "cohorts": (1, 1), "alleles": (2, 1)},
     ],
 )
 def test_cohort_allele_frequencies__polyploid(chunks):
@@ -787,7 +787,14 @@ def test_variant_stats__tetraploid():
 
 
 @pytest.mark.parametrize("precompute_variant_allele_count", [False, True])
-@pytest.mark.parametrize("chunks", [(-1, -1, -1), (100, -1, -1), (100, 10, -1)])
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        {"variants": -1, "samples": -1, "ploidy": -1},
+        {"variants": 100, "samples": -1, "ploidy": -1},
+        {"variants": 100, "samples": 10, "ploidy": -1},
+    ],
+)
 def test_variant_stats__chunks(precompute_variant_allele_count, chunks):
     ds = simulate_genotype_call_dataset(
         n_variant=1000, n_sample=30, missing_pct=0.01, seed=0
@@ -857,7 +864,14 @@ def test_sample_stats__raise_on_mixed_ploidy():
         sample_stats(ds)
 
 
-@pytest.mark.parametrize("chunks", [(-1, -1, -1), (100, -1, -1), (100, 10, -1)])
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        {"variants": -1, "samples": -1, "ploidy": -1},
+        {"variants": 100, "samples": -1, "ploidy": -1},
+        {"variants": 100, "samples": 10, "ploidy": -1},
+    ],
+)
 def test_sample_stats__chunks(chunks):
     ds = simulate_genotype_call_dataset(
         n_variant=1000, n_sample=30, missing_pct=0.01, seed=0

--- a/sgkit/tests/test_grm.py
+++ b/sgkit/tests/test_grm.py
@@ -122,8 +122,8 @@ def test_genomic_relationship__rrBLUP_diploid(estimator, chunks):
     "chunks",
     [
         None,
-        (200, 50),
-        (50, 25),
+        {"variants": 200, "samples": 50},
+        {"variants": 50, "samples": 25},
     ],
 )
 def test_genomic_relationship__tetraploid(estimator, chunks):

--- a/sgkit/tests/test_pca.py
+++ b/sgkit/tests/test_pca.py
@@ -36,7 +36,7 @@ def simulate_dataset(
     n_variant: int = 100,
     n_sample: int = 50,
     n_cohort: Optional[int] = None,
-    chunks: Any = (-1, -1),
+    chunks: Any = {"variants": -1, "samples": -1},
 ) -> Dataset:
     """Simulate dataset with optional population structure"""
     ds = simulate_genotype_call_dataset(n_variant, n_sample, seed=0)
@@ -48,7 +48,9 @@ def simulate_dataset(
             ac, dims=("variants", "samples")
         )
     else:
-        ds["call_genotype_mask"] = ds["call_genotype_mask"].chunk(chunks + (1,))
+        ds["call_genotype_mask"] = ds["call_genotype_mask"].chunk(
+            {**chunks, "ploidy": 1}
+        )
         ds = count_call_alternate_alleles(ds)
     ds["call_alternate_allele_count"] = ds["call_alternate_allele_count"].chunk(chunks)
     return ds
@@ -71,11 +73,19 @@ def allel_pca(gn: ArrayLike, randomized: bool = False, **kwargs: Any) -> Dataset
 
 
 @pytest.mark.parametrize("shape", [(100, 50), (50, 100), (50, 50)])
-@pytest.mark.parametrize("chunks", [(10, -1), (-1, 10), (-1, -1), (10, 10)])
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        {"variants": 10, "samples": -1},
+        {"variants": -1, "samples": 10},
+        {"variants": -1, "samples": -1},
+        {"variants": 10, "samples": 10},
+    ],
+)
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
 def test_pca__lazy_evaluation(shape, chunks, algorithm):
     # Ensure that all new variables are backed by lazy arrays
-    if algorithm == "tsqr" and all(c > 0 for c in chunks):
+    if algorithm == "tsqr" and all(c > 0 for c in chunks.values()):
         return
     ds = simulate_dataset(*shape, chunks=chunks)  # type: ignore[misc]
     ds = pca.pca(ds, n_components=2, algorithm=algorithm, merge=False)
@@ -139,7 +149,7 @@ def test_pca__raise_on_invalid_algorithm(sample_dataset):
 def test_pca__raise_on_incompatible_chunking(sample_dataset):
     ds = sample_dataset.assign(
         call_alternate_allele_count=lambda ds: ds["call_alternate_allele_count"].chunk(
-            (2, 2)
+            {"variants": 2, "samples": 2}
         )
     )
     with pytest.raises(
@@ -197,17 +207,19 @@ def test_pca__stats(sample_dataset):
 @pytest.fixture(scope="module", params=[(100, 50), (50, 100)])
 def stability_test_result(request):
     shape = request.param
-    ds = simulate_dataset(*shape, chunks=(-1, -1), n_cohort=3)  # type: ignore[misc]
+    ds = simulate_dataset(*shape, chunks={"variants": -1, "samples": -1}, n_cohort=3)  # type: ignore[misc]
     res = pca.pca(ds, n_components=2, algorithm="tsqr", merge=False)
     return shape, res
 
 
-@pytest.mark.parametrize("chunks", [(-1, -1), (25, 25)])
+@pytest.mark.parametrize(
+    "chunks", [{"variants": -1, "samples": -1}, {"variants": 25, "samples": 25}]
+)
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
 def test_pca__stability(stability_test_result, chunks, algorithm):
     # Ensure that results are stable across algorithms and that sign flips
     # do not occur when chunking changes
-    if algorithm == "tsqr" and all(c > 0 for c in chunks):
+    if algorithm == "tsqr" and all(c > 0 for c in chunks.values()):
         return
     shape, expected = stability_test_result
     ds = simulate_dataset(*shape, chunks=chunks, n_cohort=3)  # type: ignore[misc]
@@ -220,7 +232,14 @@ def test_pca__stability(stability_test_result, chunks, algorithm):
 
 
 @pytest.mark.parametrize("shape", [(80, 30), (30, 80)])
-@pytest.mark.parametrize("chunks", [(10, -1), (-1, 10), (-1, -1)])
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        {"variants": 10, "samples": -1},
+        {"variants": -1, "samples": 10},
+        {"variants": -1, "samples": -1},
+    ],
+)
 @pytest.mark.parametrize("n_components", [1, 2, 29])
 def test_pca__tsqr_allel_comparison(shape, chunks, n_components):
     # Validate chunked, non-random implementation vs scikit-allel single chunk results
@@ -238,7 +257,7 @@ def test_pca__tsqr_allel_comparison(shape, chunks, n_components):
 
 
 @pytest.mark.parametrize("shape", [(300, 200), (200, 300)])
-@pytest.mark.parametrize("chunks", [(50, 50)])
+@pytest.mark.parametrize("chunks", [{"variants": 50, "samples": 50}])
 @pytest.mark.parametrize("n_components", [1, 2])
 def test_pca__randomized_allel_comparison(shape, chunks, n_components):
     # Validate chunked, randomized implementation vs scikit-allel single chunk results --

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -206,7 +206,7 @@ def test_max_str_len(dtype, chunks, backend, data):
     if dtype == "O":
         x = x.astype(object)
     if chunks is not None and backend is xr.DataArray:
-        x = x.chunk(chunks=(chunks,) * ndim)
+        x = x.chunk({dim: chunks for dim in x.dims})
     if chunks is not None and backend is da.array:
         x = x.rechunk((chunks,) * ndim)
     if x.size == 0:


### PR DESCRIPTION
The Cubed workflow has been red for a while. Two independent problems:

1. `cubed` and `cubed-xarray` now require Python >= 3.12, so the install step failed:
   ```
   ERROR: Package 'cubed' requires a different Python: 3.11.16 not in '>=3.12'
   ```
   First commit bumps the job to 3.12.

2. With that fixed, 10 tests failed because xarray main now warns on tuple chunks and warnings are errors:
   ```
   FutureWarning: Supplying chunks as dimension-order tuples is deprecated.
   It will raise an error in the future. Instead use a dict with dimension names as keys.
   ```
   Second commit rewrites the test parametrizations to use dimension names (`{"variants": 100, "samples": 10, "ploidy": -1}` instead of `(100, 10, -1)`), so the call sites stay as they were. Also updates the rechunking hint in `pca.py` to the dict form. Tests pass locally against both the pinned xarray 2025.3.0 and xarray main.

Verified green on my fork: https://github.com/Billyzhang1229/sgkit/actions/runs/33771138386