### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,11 +17,11 @@ jobs:
     if: github.repository_owner == 'sgkit-dev'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # To fetch all commits to be able to generate benchmarks html
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/.github/workflows/build-gpu.yml
+++ b/.github/workflows/build-gpu.yml
@@ -20,14 +20,14 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run Nvidia-smi
         run: |
           nvidia-smi
 
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v4
         env:
           CONDA: /home/runnerx/miniconda3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -45,8 +45,8 @@ jobs:
       matrix:
         zarr: [">=3"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,12 +35,12 @@ jobs:
       run: |
         cd docs
         make html SPHINXOPTS="-W --keep-going -n"
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: gwas_tutorial
         path: /home/runner/work/sgkit/sgkit/docs/_build/html/reports/examples/gwas_tutorial.err.log
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: relatedness_tutorial

--- a/.github/workflows/cubed.yml
+++ b/.github/workflows/cubed.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11"
     - name: Install dependencies

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'sgkit-dev'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
         python -m build --sdist --wheel
         python -m twine check --strict dist/*
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: dist
 
@@ -50,13 +50,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # checkout repo to subdirectory to get access to scripts
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           path: sgkit-copy
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8
+        with:
+          name: artifact
+          path: artifact
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install wheel and test
@@ -79,13 +82,16 @@ jobs:
         python-version: ["3.11"]
     steps:
       # checkout repo to subdirectory to get access to scripts
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           path: sgkit-copy
       - name: Download artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8
+        with:
+          name: artifact
+          path: artifact
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install wheel and test
@@ -105,7 +111,10 @@ jobs:
     needs: ['unix-test', 'windows-test']
     steps:
       - name: Download all
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v8
+        with:
+          name: artifact
+          path: artifact
       - name: Move to dist
         run: |
           mkdir dist


### PR DESCRIPTION
GitHub removes Node 20 from hosted runners on 2026-09-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)); CI on `main` is already annotating every run with the deprecation warning. This bumps each JavaScript action to its current major:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-python | v5 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4.1.7 | v8 |
| codecov/codecov-action | v3 | v7 |
| conda-incubator/setup-miniconda | v2.2.0 | v4 |

Checked the breaking-change notes for each: `setup-python` v7 removed the `pip-install` input (unused), `codecov` v4+ needs a token (already passed), `setup-miniconda` v3+ defaults to the libmamba solver (only used in the manually-triggered GPU workflow now that #1344 is in). `actionlint` reports no new issues.

One real behaviour change: since `download-artifact` v5, a download with no `name` that finds exactly one artifact extracts it straight into the target path instead of an `artifact/` subdirectory ([source](https://github.com/actions/download-artifact/blob/v8/src/download-artifact.ts): `artifacts.length === 1 ? resolvedPath : path.join(resolvedPath, artifact.name)`). The `wheels.yml` test and upload jobs relied on that subdirectory, so the download steps now pass `name: artifact` and `path: artifact` explicitly.

Left alone: `google-github-actions/setup-gcloud@v0` in `validation.yml`, since v1+ dropped `service_account_key` and the workflow has been disabled since 2024 (the `sgkit-data` bucket it downloads from no longer exists, see #1332). `pre-commit/action` and `pypa/gh-action-pypi-publish` are composite actions and unaffected.

Rebased on `main` after #1344 and #1345.