### PR TITLE
Fix benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           sudo apt update -y
           python -m pip install --upgrade pip
-          pip install asv
+          pip install asv==0.6.6
 
       - name: Set and log asv machine configuration
         run: |

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -27,10 +27,9 @@
        "in-dir={build_dir} python -m pip install ."
      ],
     // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": [
-    //     "python setup.py build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
+     "build_command": [
+       "python -m pip wheel --no-deps -w {build_cache_dir} {build_dir}"
+     ],
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).

--- a/benchmarks/benchmarks_stats.py
+++ b/benchmarks/benchmarks_stats.py
@@ -19,7 +19,7 @@ class TimeSuite:
             n_variant=100_000, n_sample=1000
         )
         sample_cohort = np.repeat(
-            [0, 1], self.count_cohort_alleles_ds.dims["samples"] // 2
+            [0, 1], self.count_cohort_alleles_ds.sizes["samples"] // 2
         )
         self.count_cohort_alleles_ds["sample_cohort"] = xr.DataArray(
             sample_cohort, dims="samples"

--- a/benchmarks/benchmarks_stats.py
+++ b/benchmarks/benchmarks_stats.py
@@ -24,9 +24,16 @@ class TimeSuite:
         self.count_cohort_alleles_ds["sample_cohort"] = xr.DataArray(
             sample_cohort, dims="samples"
         )
+        # jit warmup
+        warmup_ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10)
+        warmup_ds["sample_cohort"] = xr.DataArray(
+            np.repeat([0, 1], warmup_ds.sizes["samples"] // 2), dims="samples"
+        )
+        count_call_alleles(warmup_ds).call_allele_count.compute()
+        count_cohort_alleles(warmup_ds).cohort_allele_count.compute()
 
     def time_count_call_alleles(self) -> None:
-        count_call_alleles(self.count_call_alleles_ds)
+        count_call_alleles(self.count_call_alleles_ds).call_allele_count.compute()
 
     def time_count_cohort_alleles(self) -> None:
-        count_cohort_alleles(self.count_cohort_alleles_ds)
+        count_cohort_alleles(self.count_cohort_alleles_ds).cohort_allele_count.compute()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ cbgen > 1.0.5
 bio2zarr[vcf]; platform_system != "Windows"
 yarl
 matplotlib
-asv
+asv >= 0.6.6
 networkx
 aiohttp
 requests


### PR DESCRIPTION
The benchmarks workflow has been red. Two independent problems:

1. `benchmarks/asv.conf.json` leaves `build_command` commented out, so asv uses
   its default, which runs `pip wheel` without `--no-deps` and drops a wheel for
   every dependency into the build cache. asv 0.6.6 turned more than one wheel
   there into a hard error:
   ```
   ·· Last error: Found multiple wheels in .../asv-build-cache/... Cannot decide correct one
   ```
   First commit sets `build_command` explicitly, which also stops the job
   depending on asv's defaults. A later commit pins asv, since its version is
   not recorded in the results.

2. `count_call_alleles` and `count_cohort_alleles` return lazy dask arrays and
   the benchmarks never computed them, so they were timing the construction of
   the task graph rather than the counting — which is why they have reported an
   almost unchanging 0.12s for years. Both now compute the result, with a numba
   warmup in `setup` so jit compilation is not measured.

The second change moves them from ~0.12s to ~1.1s and resets their history, as
the old values were measuring something else. 

Verified by a full successful run of the workflow on a fork.